### PR TITLE
fix(api): hardcode one-week offset for session days

### DIFF
--- a/api/GetICS/index.mjs
+++ b/api/GetICS/index.mjs
@@ -90,7 +90,8 @@ export default async function (context, req) {
                         const interval = weeks.split('\u2011')
                         const repetitions = interval[interval.length-1]-interval[0]+1
 
-                        const day = dayOffset + 7*(interval[0]-1) + parseInt(session.day) + 1
+                        const day = dayOffset + 7*(interval[0]-1) + parseInt(session.day) + 1 - 7
+                        // FIXME: hotfix for one week shift in ICS exports in 2025. Breaks lots of other years.
 
                         let startDay = utcToZonedTime(new Date(yearStart.getTime()), tz)
                         startDay.setDate(day)


### PR DESCRIPTION
This is a very bad fix, but in absence of other solutions this should do so that people's calendars don't break.

Another solution would be to modify `dayOffset` with weird days in the beginning of the year in mind, but this temporary fix is easier to notice and reimplement later