### PR TITLE
Add on-hover titles to events

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -45,13 +45,13 @@ const formatEventContent = (setSpecifiedOccurrences, setHiddenEvents, { event, v
       <div className='hide-button' title='Hide this event' onClick={() => setHiddenEvents(events => [...events, values])}>
         <svg viewBox="0 0 24 24"><path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"></path></svg>
       </div>
-      <p>{event.title}</p>
-      <p>{locationLine}</p>
+      <p title='{event.title}'>{event.title}</p>
+      <p title='{location}'>{locationLine}</p>
       <p>{button}</p>
     </>)
   } else return <>
     <div className="fc-daygrid-event-dot" style={{ borderColor: borderColor }}></div>
-    <div className="fc-event-title">{event.title}</div>
+    <div title='{event.title}' className="fc-event-title">{event.title}</div>
   </>
 }
 


### PR DESCRIPTION
When there are many events squeezed together in one day, it's helpful to be able to see the full event name and location.